### PR TITLE
renamed metric to actual nginx stub names

### DIFF
--- a/bin/nginx-metrics.rb
+++ b/bin/nginx-metrics.rb
@@ -99,9 +99,9 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
       end
       if line.match(/^\s+(\d+)\s+(\d+)\s+(\d+)/)
         requests = line.match(/^\s+(\d+)\s+(\d+)\s+(\d+)/).to_a
-        output "#{config[:scheme]}.accepted", requests[1]
+        output "#{config[:scheme]}.accepts", requests[1]
         output "#{config[:scheme]}.handled", requests[2]
-        output "#{config[:scheme]}.handles", requests[3]
+        output "#{config[:scheme]}.requests", requests[3]
       end
       if line.match(/^Reading:\s+(\d+).*Writing:\s+(\d+).*Waiting:\s+(\d+)/)
         queue = line.match(/^Reading:\s+(\d+).*Writing:\s+(\d+).*Waiting:\s+(\d+)/).to_a


### PR DESCRIPTION
rename accepted and handles to be accepts and requests respectively, the field names as returned by stub nginx, http://nginx.org/en/docs/http/ngx_http_stub_status_module.html#stub_status