### PR TITLE
Update nginx-metrics.rb

### DIFF
--- a/bin/nginx-metrics.rb
+++ b/bin/nginx-metrics.rb
@@ -57,8 +57,8 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
          default: 'nginx_status'
 
   option :hostheader,
-	 long: '--hostheader HOSTHEADER',
-	 description: 'Set the Host header to this string'
+         long: '--hostheader HOSTHEADER',
+         description: 'Set the Host header to this string'
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',

--- a/bin/nginx-metrics.rb
+++ b/bin/nginx-metrics.rb
@@ -81,9 +81,9 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
         request = Net::HTTP::Get.new(uri.request_uri)
-	if config[:hostheader]
-	  request['Host'] = config[:hostheader]
-	end
+        if config[:hostheader]
+          request['Host'] = config[:hostheader]
+        end
         response = http.request(request)
         if response.code == '200'
           found = true

--- a/bin/nginx-metrics.rb
+++ b/bin/nginx-metrics.rb
@@ -56,6 +56,10 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Path to your stub status module',
          default: 'nginx_status'
 
+  option :hostheader,
+	 long: '--hostheader HOSTHEADER',
+	 description: 'Set the Host header to this string'
+
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',
          short: '-s SCHEME',
@@ -77,6 +81,9 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
         request = Net::HTTP::Get.new(uri.request_uri)
+	if config[:hostheader]
+	  request['Host'] = config[:hostheader]
+	end
         response = http.request(request)
         if response.code == '200'
           found = true


### PR DESCRIPTION
If multiple different sites are hosted on the same Nginx instance, and you want stats only for one of them, you will have to specify a custom Host header in your request, which will be different from the hostname part in the URL.

Also, sometimes it's easier to allow the stats page to be accessed only from localhost, and block it for the rest. Then, again, you'll need a custom Host header. Example:

./nginx-metrics.rb -u http://127.0.0.1/nginx_status --hostheader 'my.site.com'

For these reasons, I've added an option to allow custom values for the Host header that cannot be deduced from the URL.