### PR TITLE
Fix for hostheader without setting url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- `check-nginx-status.rb`: Fixed usage of hostheader without setting url
 
 ## [2.2.2] - 2018-03-28
 ### Security

--- a/bin/check-nginx-status.rb
+++ b/bin/check-nginx-status.rb
@@ -103,6 +103,7 @@ class CheckNginxStatus < Sensu::Plugin::Check::CLI
         else
           response = Net::HTTP.start(config[:hostname], config[:port]) do |connection|
             request = Net::HTTP::Get.new("/#{config[:path]}")
+            request['Host'] = config[:hostheader] if config[:hostheader]
             connection.request(request)
           end
         end


### PR DESCRIPTION
This fixes the hostheader option to be used without setting the url option. Useful for connecting to localhost with a specific hostheader set.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
