### PR TITLE
do not query http server 10 times unnecessarily

### DIFF
--- a/bin/metrics-nginx.rb
+++ b/bin/metrics-nginx.rb
@@ -95,16 +95,16 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
           request['Authorization'] = "Bearer #{config[:token]}"
         end
         response = http.request(request)
-        if response.code == '200'
-          found = true
-        elsif !response.header['location'].nil?
-          config[:url] = response.header['location']
-        end
       else
         response = Net::HTTP.start(config[:hostname], config[:port]) do |connection|
           request = Net::HTTP::Get.new("/#{config[:path]}")
           connection.request(request)
         end
+      end
+      if response.code == '200'
+        found = true
+      elsif !response.header['location'].nil?
+        config[:url] = response.header['location']
       end
     end
 


### PR DESCRIPTION
"found" is never set to true when no URL is specified.  This creates 10 attempts even if successful every time the metrics script is run.  You can verify this by looking at your nginx logs, you'll see 10 entries for each run.